### PR TITLE
Update mock annotations and pre-create schema for PostgreSQL container

### DIFF
--- a/spring-services-all/src/test/java/com/example/aggregate/AggregateTestConfig.java
+++ b/spring-services-all/src/test/java/com/example/aggregate/AggregateTestConfig.java
@@ -17,7 +17,10 @@ public class AggregateTestConfig {
   @Bean
   @ServiceConnection
   public PostgreSQLContainer<?> postgresContainer() {
-    return new PostgreSQLContainer<>("postgres:16-alpine");
+    return new PostgreSQLContainer<>("postgres:16-alpine")
+        // Pre-create the dedicated schema so Hibernate's create-drop startup DROP phase does not
+        // log a CommandAcceptanceException for the not-yet-existing oe_spring_services schema.
+        .withInitScript("db/create-schema.sql");
   }
 
   @Bean

--- a/spring-services-all/src/test/resources/db/create-schema.sql
+++ b/spring-services-all/src/test/resources/db/create-schema.sql
@@ -1,0 +1,5 @@
+-- Pre-create the library's dedicated schema so Hibernate's create-drop startup DROP phase
+-- (which emits an unguarded "drop schema oe_spring_services") has an existing schema to drop
+-- on the first run against a fresh Testcontainer. Without this, Hibernate logs a harmless but
+-- noisy CommandAcceptanceException before recreating the schema.
+CREATE SCHEMA IF NOT EXISTS oe_spring_services;

--- a/spring-services-core/src/test/java/com/openelements/spring/base/security/user/UserServiceActiveGateIntegrationTest.java
+++ b/spring-services-core/src/test/java/com/openelements/spring/base/security/user/UserServiceActiveGateIntegrationTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.access.AccessDeniedException;
@@ -49,7 +49,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * transactional configuration — entities are flushed and reloaded across transactions so the
  * assertions reflect what is durably in the database, not just the session cache.
  *
- * <p><b>Mock-Audit.</b> A single {@code @MockBean AuthService} is the only mock. The real
+ * <p><b>Mock-Audit.</b> A single {@code @MockitoBean AuthService} is the only mock. The real
  * {@code AuthService} would require a Spring Security {@code SecurityContextHolder} populated by
  * the filter chain, which these tests deliberately bypass to drive {@code getCurrentUserEntity()}
  * directly. The {@code UserService}, {@link UserRepository}, and {@code UserProvisioner} under
@@ -68,7 +68,7 @@ class UserServiceActiveGateIntegrationTest {
 
   @Autowired private JdbcTemplate jdbcTemplate;
 
-  @MockBean private AuthService authService;
+  @MockitoBean private AuthService authService;
 
   /**
    * Deletes dependent {@code audit_log} rows before the {@code users} rows they reference, then

--- a/spring-services-core/src/test/java/com/openelements/spring/base/security/user/UserServiceConcurrencyTest.java
+++ b/spring-services-core/src/test/java/com/openelements/spring/base/security/user/UserServiceConcurrencyTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
@@ -69,7 +69,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * in-memory database faithfully reproduces.
  *
  * <p><b>Mock surface and justification.</b> {@link
- * com.openelements.spring.base.security.AuthService} is the single {@code @MockBean} — it would
+ * com.openelements.spring.base.security.AuthService} is the single {@code @MockitoBean} — it would
  * otherwise require a Spring Security {@code SecurityContextHolder} populated by the filter
  * chain, which the tests deliberately bypass to drive {@code getCurrentUserEntity()} directly
  * on background threads. Per-thread {@code UserInformation} dispatch is implemented with a
@@ -100,7 +100,7 @@ class UserServiceConcurrencyTest {
 
   @Autowired private JdbcTemplate jdbcTemplate;
 
-  @MockBean private AuthService authService;
+  @MockitoBean private AuthService authService;
 
   /**
    * Deletes dependent {@code audit_log} rows before the {@code users} rows they reference, then

--- a/spring-services-core/src/test/java/com/openelements/spring/base/services/apikey/ApiKeyDataServiceIntegrationTest.java
+++ b/spring-services-core/src/test/java/com/openelements/spring/base/services/apikey/ApiKeyDataServiceIntegrationTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -46,7 +46,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * service, and the {@link ApiKeyRepository} is the real Spring Data repository writing to the
  * containerised database.
  *
- * <p><b>Mock-Audit.</b> Two {@code @MockBean}s:
+ * <p><b>Mock-Audit.</b> Two {@code @MockitoBean}s:
  *
  * <ul>
  *   <li>{@code UserService} — stubbed to return a static "Test Admin" {@code UserDto}. The
@@ -68,9 +68,9 @@ class ApiKeyDataServiceIntegrationTest {
 
   @Autowired private ApiKeyRepository apiKeyRepository;
 
-  @MockBean private UserService userService;
+  @MockitoBean private UserService userService;
 
-  @MockBean private AuthService authService;
+  @MockitoBean private AuthService authService;
 
   @BeforeEach
   void setUp() {

--- a/spring-services-core/src/test/java/com/openelements/spring/base/services/audit/AuditLogIntegrationTest.java
+++ b/spring-services-core/src/test/java/com/openelements/spring/base/services/audit/AuditLogIntegrationTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -62,7 +62,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * starts a real Postgres via Testcontainers. {@link TagDataService} is used as a real publisher
  * of {@code OnObjectCreate/Update/Delete} events so the integration is end-to-end.
  *
- * <p><b>Mock-Audit.</b> {@code AuthService} is the single {@code @MockBean} — real
+ * <p><b>Mock-Audit.</b> {@code AuthService} is the single {@code @MockitoBean} — real
  * {@code AuthService} reads from {@link
  * org.springframework.security.core.context.SecurityContextHolder} populated by the filter
  * chain, which the tests deliberately bypass to drive listener decisions directly. Every other
@@ -94,7 +94,7 @@ class AuditLogIntegrationTest {
 
   @Autowired private JdbcTemplate jdbcTemplate;
 
-  @MockBean private AuthService authService;
+  @MockitoBean private AuthService authService;
 
   private UserEntity alice;
   private UserEntity bob;

--- a/spring-services-core/src/test/java/com/openelements/spring/base/services/tag/TagDataServiceIntegrationTest.java
+++ b/spring-services-core/src/test/java/com/openelements/spring/base/services/tag/TagDataServiceIntegrationTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -41,7 +41,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * are real beans; the per-test {@code @BeforeEach} truncates the {@code tag} table to keep
  * scenarios independent.
  *
- * <p><b>Mock-Audit.</b> One {@code @MockBean} of {@link AuthService}. The service inherits from
+ * <p><b>Mock-Audit.</b> One {@code @MockitoBean} of {@link AuthService}. The service inherits from
  * {@code AbstractDbBackedDataService}, whose audit hooks consult {@code AuthService} for the
  * acting principal — outside a real HTTP request there is no JWT to resolve, so the bean is
  * mocked to default-stub behaviour. No other collaborator is mocked: every assertion is made
@@ -58,7 +58,7 @@ class TagDataServiceIntegrationTest {
 
   @Autowired private TagRepository tagRepository;
 
-  @MockBean private AuthService authService;
+  @MockitoBean private AuthService authService;
 
   @BeforeEach
   void setUp() {

--- a/spring-services-core/src/test/java/com/openelements/spring/base/services/webhook/data/WebhookDataServiceIntegrationTest.java
+++ b/spring-services-core/src/test/java/com/openelements/spring/base/services/webhook/data/WebhookDataServiceIntegrationTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -42,7 +42,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * WebhookRepository} are real beans; the per-test {@code @BeforeEach} truncates the {@code
  * webhook} table to keep scenarios independent.
  *
- * <p><b>Mock-Audit.</b> One {@code @MockBean} of {@link AuthService}. The service inherits from
+ * <p><b>Mock-Audit.</b> One {@code @MockitoBean} of {@link AuthService}. The service inherits from
  * {@code AbstractDbBackedDataService}, whose audit hooks consult {@code AuthService} for the
  * acting principal — outside a real HTTP request there is no JWT to resolve, so the bean is
  * mocked to default-stub behaviour. No other collaborator is mocked: every assertion is made
@@ -59,7 +59,7 @@ class WebhookDataServiceIntegrationTest {
 
   @Autowired private WebhookRepository webhookRepository;
 
-  @MockBean private AuthService authService;
+  @MockitoBean private AuthService authService;
 
   @BeforeEach
   void setUp() {

--- a/spring-services-core/src/test/java/com/openelements/spring/base/testcontainers/PostgresTestConfiguration.java
+++ b/spring-services-core/src/test/java/com/openelements/spring/base/testcontainers/PostgresTestConfiguration.java
@@ -17,7 +17,10 @@ public class PostgresTestConfiguration {
   @Bean
   @ServiceConnection
   public PostgreSQLContainer<?> postgresContainer() {
-    return new PostgreSQLContainer<>("postgres:16-alpine");
+    return new PostgreSQLContainer<>("postgres:16-alpine")
+        // Pre-create the dedicated schema so Hibernate's create-drop startup DROP phase does not
+        // log a CommandAcceptanceException for the not-yet-existing oe_spring_services schema.
+        .withInitScript("db/create-schema.sql");
   }
 
   @Bean

--- a/spring-services-core/src/test/resources/application-testcontainers.properties
+++ b/spring-services-core/src/test/resources/application-testcontainers.properties
@@ -2,9 +2,12 @@ spring.jpa.hibernate.ddl-auto=create-drop
 # Required so create-drop provisions the dedicated oe_spring_services schema before creating the
 # schema-qualified tables (Hibernate does not create a namespace/schema for an entity otherwise).
 spring.jpa.properties.hibernate.hbm2ddl.create_namespaces=true
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+# generate_statistics stays enabled: CommentServiceIntegrationTest asserts batch-fetch behaviour
+# via the Hibernate Statistics API (SessionFactory.getStatistics()). It is the collection of the
+# stats we need, not their logging — so we silence the per-session "Session Metrics {...}" dumps
+# that StatisticalLoggingSessionEventListener would otherwise emit at INFO for every session.
 spring.jpa.properties.hibernate.generate_statistics=true
+logging.level.org.hibernate.engine.internal.StatisticalLoggingSessionEventListener=WARN
 
 # Allow PostgresTestConfiguration test beans (e.g. webhookRestClient) to override the
 # production beans from the library's @Configuration classes.

--- a/spring-services-core/src/test/resources/db/create-schema.sql
+++ b/spring-services-core/src/test/resources/db/create-schema.sql
@@ -1,0 +1,5 @@
+-- Pre-create the library's dedicated schema so Hibernate's create-drop startup DROP phase
+-- (which emits an unguarded "drop schema oe_spring_services") has an existing schema to drop
+-- on the first run against a fresh Testcontainer. Without this, Hibernate logs a harmless but
+-- noisy CommandAcceptanceException before recreating the schema.
+CREATE SCHEMA IF NOT EXISTS oe_spring_services;


### PR DESCRIPTION
This pull request makes two main types of improvements: it updates the test configuration to pre-create the required database schema for Hibernate, preventing noisy exceptions during test startup, and it migrates all test usage of `@MockBean` to the new `@MockitoBean` annotation from `spring-test-bean-override`. Additionally, it adjusts Hibernate logging to reduce noise during test runs.
